### PR TITLE
docs: update all references of `skills/response-templates` to use `skills/exercise-toolkit` instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,17 +95,17 @@ steps:
   - name: Get templates from another repository
     uses: actions/checkout@v4
     with:
-      repository: skills/response-templates
-      path: response-templates
+      repository: skills/exercise-toolkit
+      path: exercise-toolkit
 
   - name: Show available templates
-    run: ls -R response-templates
+    run: ls -R exercise-toolkit/markdown-templates
 
   - name: Build comment using template
     id: build-comment
     uses: skills/action-text-variables@v1
     with:
-      template-file: response-templates/step-feedback/lesson-finished.md
+      template-file: exercise-toolkit/markdown-templates/step-feedback/lesson-finished.md
       template-vars: >
         {
           "login": "${{ github.actor }}",

--- a/examples/template-from-other-repo.yml
+++ b/examples/template-from-other-repo.yml
@@ -14,17 +14,17 @@ jobs:
       - name: Get templates from another repository
         uses: actions/checkout@v4
         with:
-          repository: skills/response-templates
-          path: response-templates
+          repository: skills/exercise-toolkit
+          path: exercise-toolkit
 
       - name: Show available templates
-        run: ls -R response-templates
+        run: ls -R exercise-toolkit/markdown-templates/
 
       - name: Build comment using template
         id: build-comment
         uses: skills/action-text-variables@v1
         with:
-          template-file: response-templates/step-feedback/lesson-finished.md
+          template-file: exercise-toolkit/markdown-templates/step-feedback/lesson-finished.md
           template-vars: >
             {
               "login": "${{ github.actor }}",


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

We now host markdown templates in https://github.com/skills/exercise-toolkit

### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
