### PR TITLE
fix: Correct inputs description to use YAML, not ENV.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ file will be ignored.
 | --------------- | ------------------------------------------------ | -------- |
 | `template-file` | The path to a text file to load as the template. | No\*     |
 | `template-text` | The template text with variable placeholders.    | No\*     |
-| `template-vars` | An ENV style list or stringified JSON object.    | Yes      |
+| `template-vars` | A YAML dictionary or JSON object.                | Yes      |
 
 \*One of either `template-file` or `template-text` must be provided.
 


### PR DESCRIPTION
This pull request updates the documentation in `README.md` to clarify the supported formats for the `template-vars` parameter.

* **Documentation Update**:
  - Updated the description of the `template-vars` parameter to specify that it accepts a YAML dictionary or JSON object, replacing the previous mention of an "ENV style list or stringified JSON object." (`README.md`)